### PR TITLE
Upgrade spring-boot-autoconfigure to version 3.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,12 @@
             <version>1.2.0</version>
         </dependency>
 
-    </dependencies>
+      <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-autoconfigure</artifactId>
+         <version>3.3.0</version>
+      </dependency>
+   </dependencies>
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>


### PR DESCRIPTION
![large-logo-191x34](https://user-images.githubusercontent.com/33268211/98482806-aa4ffd00-21b8-11eb-8a44-82947e3acf9a.png)<p>Upgrades spring-boot-autoconfigure to 3.3.0 to fix vulnerabilities in current version